### PR TITLE
Mount requirements from a requirements directory

### DIFF
--- a/docker/docker-compose-local.yml
+++ b/docker/docker-compose-local.yml
@@ -30,7 +30,7 @@ services:
         volumes:
             - ${HDW_AIRFLOW_ROOT}/dags:/usr/local/airflow/dags
             - ${HDW_AIRFLOW_ROOT}/plugins:/usr/local/airflow/plugins
-            - ${HDW_AIRFLOW_ROOT}:/usr/local/airflow/requirements
+            - ${HDW_AIRFLOW_ROOT}/requirements:/usr/local/airflow/requirements
             - ${HOME}/.aws:/usr/local/airflow/.aws
         ports:
             - "8085:8080"


### PR DESCRIPTION
Using the root of the HDW_AIRFLOW_ROOT was causing some task_ids to be loaded into the same dag twice.